### PR TITLE
Update GameModel.java to make the "revoke" correct

### DIFF
--- a/desktop/src/connect6ng/GameModel.java
+++ b/desktop/src/connect6ng/GameModel.java
@@ -262,7 +262,7 @@ public class GameModel extends Observable implements Serializable  {
 	 * @return 上一步的颜色
 	 */
 	public int getLastColor(){
-		return (getSize()%4)/2;
+		return ((getSize()+1)%4)/2;
 	}
 	
 	/** 返回当前可以下的颜色


### PR DESCRIPTION
悔棋的逻辑是正确的，错误的是其中用到的函数：getLastColor()
对棋盘上对总子数模4取余，得到的结果是0、1对应的是先手，2、3应该对应的后手；
可以想到，实际情况是，1、2应该对应对是先手，3、4应该对应的后手。